### PR TITLE
Add changelog content

### DIFF
--- a/lib/generate-changelog.js
+++ b/lib/generate-changelog.js
@@ -1,0 +1,18 @@
+/*jshint esversion: 6 */
+
+const releaseNotes = require('git-release-notes');
+
+const OPTIONS = {
+  branch: 'master',
+};
+const RANGE = 'HEAD~5..HEAD';
+const TEMPLATE = 'html-bootstrap';
+
+releaseNotes(OPTIONS, RANGE, TEMPLATE)
+.then((changelog) => {
+  console.log(changelog);
+})
+.catch((ex) => {
+  console.error(ex);
+  process.exit(1);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -2508,6 +2508,12 @@
         "assert-plus": "^1.0.0"
       }
     },
+    "date-fns": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
+      "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
+      "dev": true
+    },
     "date-format": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/date-format/-/date-format-2.0.0.tgz",
@@ -2811,6 +2817,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+      "dev": true
+    },
+    "ejs": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.6.1.tgz",
+      "integrity": "sha512-0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ==",
       "dev": true
     },
     "electron-to-chromium": {
@@ -4229,6 +4241,35 @@
       "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
+      }
+    },
+    "git-release-notes": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/git-release-notes/-/git-release-notes-4.0.1.tgz",
+      "integrity": "sha512-M4jDMvseUWZinaDAhowpUvMfA6SDpTMjip2sIeGFyKs+exHcfdpVEUy7vQTuEXCFa0PZCV0Nps3jYN5GrXAH/g==",
+      "dev": true,
+      "requires": {
+        "date-fns": "^1.30.1",
+        "debug": "^4.1.1",
+        "ejs": "^2.6.1",
+        "yargs": "^12.0.5"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        }
       }
     },
     "glob": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@types/jasminewd2": "~2.0.3",
     "@types/node": "^10.12.18",
     "codelyzer": "^4.5.0",
+    "git-release-notes": "^4.0.1",
     "jasmine-core": "^3.3.0",
     "jasmine-spec-reporter": "~4.2.1",
     "karma": "^4.1.0",

--- a/src/app/changelog/changelog.component.html
+++ b/src/app/changelog/changelog.component.html
@@ -1,1 +1,0 @@
-<app-under-construction></app-under-construction>

--- a/src/app/changelog/changelog.component.html
+++ b/src/app/changelog/changelog.component.html
@@ -1,0 +1,110 @@
+<div class="container" role="main">
+  <div class="row">
+    <h1>Release Notes</h1>
+  </div>
+
+  <div class="row">
+    <div class="header title">
+      <h2>Commits</h2>
+    </div>
+    <table id="commitTable" class="table table-bordered table-striped table-hover">
+      <thead>
+        <tr>
+          <th>Date</th>
+          <th>Author</th>
+          <th>Commit</th>
+        </tr>
+      </thead>
+      <tbody>
+
+        <tr>
+          <td nowrap="nowrap"><span style="display:none">2019-06-017T21:09:03&nbsp;</span>17-Jun-2019 09:09</td>
+          <td>Cody Flatla</td>
+          <td>
+            Add changelog content (#9)
+
+            <pre>
+* Copy output from release-notes script to changelog
+
+* Add git-release-notes module and script
+
+https://github.com/ariatemplates/git-release-notes
+
+* Remove construction component from changelog
+</pre>
+          </td>
+        </tr>
+
+        <tr>
+          <td nowrap="nowrap"><span style="display:none">2019-06-02T03:31:23&nbsp;</span>02-Jun-2019 03:31</td>
+          <td>Cody Flatla</td>
+          <td>
+            Improve circle config (#8)
+
+            <pre>
+* Remove branch filter from build job
+To hopefully prevent this:
+
+https://circleci.com/workflow-run/afd93b24-8d9e-44fb-b2cb-8f51fc2a17d2
+
+* Make the lint and test jobs run in parallel
+
+* Use version 2.1 to allow using commands
+
+* Dry up build job
+
+* Use cache version from environment variable
+
+* Prevent restoring cache with old version
+
+* Update package-lock to use correct Typescript
+            </pre>
+          </td>
+        </tr>
+
+        <tr>
+
+          <td nowrap="nowrap"><span style="display:none">2019-06-02T02:03:41&nbsp;</span>02-Jun-2019 02:03</td>
+          <td>Cody Flatla</td>
+          <td>
+            Downgrade Typescript to 3.4.5
+
+            <pre>
+Required by Angular Compiler
+            </pre>
+          </td>
+        </tr>
+
+        <tr>
+          <td nowrap="nowrap"><span style="display:none">2019-06-02T01:46:24&nbsp;</span>02-Jun-2019 01:46</td>
+          <td>Cody Flatla</td>
+          <td>
+            Upgrade to Angular 8, Node 12, and fix dependencies (#7)
+
+            <pre>
+* Update nvmrc to 12
+
+* Update to angular 8 via `ng update @angular/cli @angular/core`
+
+* Remove @angular/http from package.json
+
+* Replace package-lock with one that doesn&#39;t explode
+
+* Install bootstrap peer dependencies and update typescript minor version
+
+* Update circleci config to use node 12.3.1
+            </pre>
+          </td>
+        </tr>
+
+        <tr>
+          <td nowrap="nowrap"><span style="display:none">2019-05-05T19:23:34&nbsp;</span>05-May-2019 19:23</td>
+          <td>Cody Flatla</td>
+          <td>
+            Update bootstrap minor version to fix vulnerability
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/src/app/changelog/changelog.component.spec.ts
+++ b/src/app/changelog/changelog.component.spec.ts
@@ -3,9 +3,6 @@ import { Component } from '@angular/core';
 
 import { ChangelogComponent } from './changelog.component';
 
-@Component({selector: 'app-under-construction', template: ''})
-class UnderConstructionStubComponent { }
-
 describe('ChangelogComponent', () => {
   let component: ChangelogComponent;
   let fixture: ComponentFixture<ChangelogComponent>;
@@ -13,8 +10,7 @@ describe('ChangelogComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [
-        ChangelogComponent,
-        UnderConstructionStubComponent
+        ChangelogComponent
       ]
     })
     .compileComponents();

--- a/src/app/changelog/changelog.component.spec.ts
+++ b/src/app/changelog/changelog.component.spec.ts
@@ -25,4 +25,9 @@ describe('ChangelogComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should have some content', () => {
+    const compiled = fixture.debugElement.nativeElement;
+    expect(compiled.querySelector('h1').textContent).toContain('Release Notes');
+  });
 });


### PR DESCRIPTION
# What's in this PR?
This PR uses the [`git-release-notes` module](https://github.com/ariatemplates/git-release-notes) to generate content for the changelog page.

This is the first step towards programatically generating the content for the change log page. For this PR the HTML was copied into the `changelog.component.html` after running:
> `node lib/generate-changelog.js > CHANGELOG.html`

Ideally the changelog content is generated at deploy time, but this is 

# Before
> This page is currently under construction

# After
![screencapture-localhost-4200-changelog-2019-06-17-21_08_54](https://user-images.githubusercontent.com/5545625/59650663-089fba00-9144-11e9-9aa1-15a01852da71.png)
